### PR TITLE
solved 튜플 - 45.74ms 43.3mb

### DIFF
--- a/Programmers/튜플/튜플_손민락.js
+++ b/Programmers/튜플/튜플_손민락.js
@@ -1,0 +1,30 @@
+function solution(s) {
+    var answer = [];
+    
+    const count = [];
+    let tupleLen = 0;
+    let str = "";
+    
+    for (let i = 0; i < s.length; ++i) {
+        if (s[i] >= '0' && s[i] <= '9') {
+            str += s[i];
+        } else {
+            if (str) {
+                const num = +str;
+                if (!count[num]) {
+                    ++tupleLen;
+                    count[num] = 0;
+                }
+                ++count[num]
+                str = "";
+            }
+        }
+    }
+    
+    for (let i = 0; i < count.length; ++i) {
+        if (count[i]) {
+            answer[tupleLen - count[i]] = i;
+        }
+    }
+    return answer;
+}


### PR DESCRIPTION
## 💿 풀이 문제
#46 

## 📝 풀이 후기
튜플의 성질을 모른다면 평이한 문제, 안다면 쉬운 문제입니다.

처음으로 배열의 크기를 정하지 않고 값을 할당해서 문제를 해결해보았습니다.
예를 들어, 빈 배열의 24번째 요소를 0으로 할당하면, 0번부터 23번째 요소까지는 empty item 상태가 됩니다.
따라서 문자열에서 얻은 숫자를 count할 때, 문자열에 있는 숫자만 값을 할당할 수 있습니다.

이렇게 했을 때 장점은 100,001개의 값을 미리 할당하지 않으니 s에 작은 값이 들어 있다면 메모리를 덜 사용하고, for 문의 범위도 좁아집니다.
단점은 헷갈리니까 극한의 상황이 아니라면 100,0001개를 미리 할당하고 푸는 게 정신 건강에 이롭습니다.

## 📚 문제 풀이 핵심 키워드
- 문자열 탐색
- 튜플의 성질(많이 등장한 순서대로 정렬되어 있음)을 잘 이용하면 정렬하지 않고도 문제를 해결할 수 있습니다.
예를 들어, {2, 1, 3, 4}라는 튜플이 있다면 count는 {4, 3, 2, 1} 순서가 됩니다. 따라서 정답[튜플의 길이 - count] = {count에 해당하는 원소의 값}이 됩니다.

## 🤔 리뷰로 궁금한 점

## 🧑‍💻 제출자 확인 사항
- [x] Convention(commit, pr 제목)이 올바른가요?
- [x] 괄호 내 안내문은 삭제하셨나요?
- [x] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?

## 🕵️ 리뷰어 확인 사항
1. 컨벤션이 올바르지 않다면, Request Changes 해주세요.
2. 제출자의 풀이코드의 좋은 점 혹은 개선사항을 남기고 Approve 해주세요.