### PR TITLE
solved 셔틀버스 - 0.99ms 33.6mb

### DIFF
--- a/Programmers/셔틀버스/셔틀버스_손민락.js
+++ b/Programmers/셔틀버스/셔틀버스_손민락.js
@@ -1,0 +1,38 @@
+function toMinute(str) {
+    const hour = Number(str.slice(0, 2));
+    const minute = Number(str.slice(3));
+
+    return hour * 60 + minute;
+}
+
+function minuteToTime(minute) {
+    const hour = Math.floor(minute / 60);
+    minute -= hour * 60;
+    
+    return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+}
+
+function solution(n, t, m, timetable) {
+    var answer = '';
+    timetable = timetable.map((time) => toMinute(time)).sort((a, b) => a - b);
+    
+    let idx = 0;
+    for (let i = 0; i < n; ++i) {
+        let count = 0;
+        const time = 540 + i * t;
+        while (idx < timetable.length && count < m) {
+            if (timetable[idx] > time) {
+                break;
+            }
+            ++idx;
+            ++count;
+        }
+        if (count === m) {
+            answer = timetable[idx - 1] - 1;    
+        } else {
+            answer = time;
+        }
+    }
+    
+    return minuteToTime(answer);
+}


### PR DESCRIPTION
## 💿 풀이 문제
#120

## 📝 풀이 후기
문제는 쉬웠지만 Javascript의 sort() 함수를 제대로 사용하지 않아 푸는 데 오래 걸렸습니다.

Javascript의 sort() 함수를 파라미터 없이 사용하면 문자열 형태로 변환되어 각 자리수의 유니코드 코드 포인트로 변환되기 때문에, 
1000이라는 숫자와 999라는 숫자를 비교할 때 첫 자리수가 '1'이고 '9'이기 때문에 999가 뒤로 정렬됩니다.

## 📚 문제 풀이 핵심 키워드
- 정렬
- 그리디

## 🤔 리뷰로 궁금한 점

## 🧑‍💻 제출자 확인 사항
- [x] Convention(commit, pr 제목)이 올바른가요?
- [x] 괄호 내 안내문은 삭제하셨나요?
- [x] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?

## 🕵️ 리뷰어 확인 사항
1. 컨벤션이 올바르지 않다면, Request Changes 해주세요.
2. 제출자의 풀이코드의 좋은 점 혹은 개선사항을 남기고 Approve 해주세요.