### PR TITLE
solved 양궁대회 - 0.93ms 97.7mb

### DIFF
--- a/Programmers/양궁대회/양궁대회_허승경.java
+++ b/Programmers/양궁대회/양궁대회_허승경.java
@@ -1,0 +1,77 @@
+import java.util.*;
+
+/*
+아이디어: 백트래킹
+포인트: 해당 점수를 라이언이 가져가냐 vs 안 가져가냐 -> 안 가지면 화살 사용 아예 X
+*/
+class Solution {
+    int [] info;
+    int len;
+    int[] answer;
+    int maxDiff = 0;
+    public int[] solution(int n, int[] info) {
+        this.info = info;
+        len = info.length;
+        
+        answer =new int[len]; 
+        
+        backtracking(n, 0, new int[len]);
+        
+        if(maxDiff == 0) return new int[]{-1};
+        else return answer;
+    }
+    
+    void backtracking(int cnt, int idx, int [] lionInfo){
+        // 가지치기 조건 -> 판별하려는 점수다 탐색 -> 0점 도달
+        if(idx == len){
+            // 라이언의 화살이 아직 남은 경우
+            if(cnt > 0){
+                // 0점에 몰아주기(n발 전부 소진해야함)
+                lionInfo[len-1] += cnt;
+            }
+            
+            // 어피치, 라이언 점수 계산
+            int apeachScore = 0;
+            int lionScore = 0;
+            for(int i = 0; i < len; i++){
+                if(lionInfo[i] == 0 && info[i] == 0) continue;  // 둘 다 쏘지 않음
+                
+                if(lionInfo[i] > info[i]) lionScore += (len-i-1);
+                else apeachScore += (len-i-1);
+            }
+            
+            // 어피치, 라이언 점수차
+            int diff = lionScore - apeachScore;
+            if(diff > 0){
+                // 라이언 승
+                if(diff > maxDiff || (diff == maxDiff) && check(lionInfo)){
+                    maxDiff = diff; // 점수 차 갱신
+                    answer = lionInfo.clone();  // 깊은복사로 answer 갱신
+                }
+            }
+
+            if(cnt > 0) lionInfo[len-1] -= cnt;     // 화살 수 상태 복원
+            
+            return;
+        }
+        
+        // 라이언이 점수를 가져가는 경우
+        if(cnt >= info[idx]+1){
+            lionInfo[idx] = info[idx]+1;  // 어피치보다 1발 더 많아야 점수 획득
+            backtracking(cnt - lionInfo[idx], idx + 1,  lionInfo);
+            lionInfo[idx] = 0; // 원래 상태로 초기화
+        }
+        
+        // 라이언이 점수를 안 가져가는 경우 -> 화살 안 쏨
+        backtracking(cnt, idx+1, lionInfo);
+    }
+    
+    boolean check(int [] lionInfo){
+        for(int i = len-1; i >= 0; i--){
+            if(lionInfo[i] > answer[i]) return true;
+            else if(lionInfo[i] < answer[i]) return false;
+        }
+        
+        return false;   // 모두 같을 경우
+    }
+}


### PR DESCRIPTION
## 💿 풀이 문제
#142 

## 📝 풀이 후기
가지치기 조건을 잘못 설정해서 시간이 걸렸습니다.
문제를 보면서 결국, 라이언이 해당 점수를 쏘는지 vs 안 쏘는지를 결정하는 것이 문제의 포인트라고 생각했고
완전탐색+가지치기가 생각나서 백트래킹으로 접근했습니다.
단순히 화살을 다 쏜 경우를 가지치기 조건으로 설정했는데,  마지막 idx 까지 오더라도 화살을 다 쏘지 않는 경우를 생각하지 못해
시간초과가 발생했습니다.
조건을 idx가 마지막 순번까지 온 경우로 바꾸고, 그 다음 어피치와 라이언의 점수차를 구해 해결했습니다.
문제 유형이나 포인트를 잡아도, 구조 자체를 처음부터 잘 못 잡으면 소용 없다는 걸 느끼게 해주었습니다..^^

## 📚 문제 풀이 핵심 키워드
- 백트래킹
- 가지치기는 idx가 마지막 순번까지 왔을 때
- "라이언이 가장 큰 점수 차이로 우승할 수 있는 방법이 여러 가지 일 경우, 가장 낮은 점수를 더 많이 맞힌 경우를 return 해주세요." 조건 확인하기

## 🤔 리뷰로 궁금한 점
<!-- 확인받고 싶은 기준을 작성해주시면 좋습니다. -->
<!-- 운영자에게 리뷰를 받고 싶다면, Reviewer에 @hadevyi를 태그해주세요. -->

## 🧑‍💻 제출자 확인 사항
<!-- Merge가 되면, Branch를 꼭 삭제해주세요 -->
- [x] Convention(commit, pr 제목)이 올바른가요?
- [x] 괄호 내 안내문은 삭제하셨나요?
- [x] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?
